### PR TITLE
.getLink() fix

### DIFF
--- a/src/helpers/StringHelper.php
+++ b/src/helpers/StringHelper.php
@@ -14,4 +14,11 @@ class StringHelper extends \craft\helpers\StringHelper
   static public function decodeMb4(string $str): string {
     return preg_replace_callback('/&#x[0-9A-Fa-f]+;/', fn($match) => self::htmlDecode($match[0]), $str);
   }
+
+  static public function sanitizeAttributes($attrs) {
+    foreach ($attrs as $attr => $value) {
+      $attrs[$attr] = str_replace('\n', '', trim($value));
+    }
+    return $attrs;
+  }
 }

--- a/src/models/Link.php
+++ b/src/models/Link.php
@@ -14,6 +14,7 @@ use lenz\craft\utils\foreignField\ForeignFieldModel;
 use lenz\craft\utils\helpers\ArrayHelper;
 use lenz\linkfield\fields\LinkField;
 use Twig\Markup;
+use lenz\linkfield\helpers\StringHelper;
 
 /**
  * Class Link
@@ -214,7 +215,7 @@ class Link extends ForeignFieldModel
       return null;
     }
 
-    return Template::raw(Html::tag('a', $text, $attributes));
+    return Template::raw(Html::tag('a', $text, StringHelper::sanitizeAttributes($attributes)));
   }
 
   /**
@@ -228,7 +229,7 @@ class Link extends ForeignFieldModel
     $attributes = $this->getRawLinkAttributes($extraAttributes);
     return Template::raw(is_null($attributes)
       ? ''
-      : Html::renderTagAttributes($attributes)
+      : Html::renderTagAttributes(StringHelper::sanitizeAttributes($attributes))
     );
   }
 
@@ -295,7 +296,7 @@ class Link extends ForeignFieldModel
       $attributes = array_merge($attributes, $extraAttributes);
     }
 
-    return $attributes;
+    return StringHelper::sanitizeAttributes($attributes);
   }
 
   /**


### PR DESCRIPTION
The .getLink() method fails when it's called
with a "class" option

What's done:
- Remove whitespaces and line breaks from
  the beginning and end of a class string