### PR TITLE
[fix-sanitize-array] Fix a bug StringHelper::sanitizeAttributes

### DIFF
--- a/src/helpers/StringHelper.php
+++ b/src/helpers/StringHelper.php
@@ -17,7 +17,15 @@ class StringHelper extends \craft\helpers\StringHelper
 
   static public function sanitizeAttributes($attrs) {
     foreach ($attrs as $attr => $value) {
-      $attrs[$attr] = str_replace('\n', '', trim($value));
+      if (is_array($value)) {
+        foreach ($value as $k => $v) {
+          $value[$k] = str_replace('\n', '', trim($v));
+        }
+
+        $attrs[$attr] = array_filter($value);
+      } else {
+        $attrs[$attr] = str_replace('\n', '', trim($value));
+      }
     }
     return $attrs;
   }


### PR DESCRIPTION
Bug triggered when value passed in getLink method is array like { class: ['class1', 'class2']}